### PR TITLE
feat : pagination 서버로 요청하는 방식으로 수정

### DIFF
--- a/src/api/book.ts
+++ b/src/api/book.ts
@@ -1,8 +1,12 @@
 import apiClient from "./apiClient";
 import {BookType} from "@/types/aboutBook";
 export const getBooks = ()=>{
-    return apiClient.get('/api/books');
+    return apiClient.get(`/api/books`);
 }
+export const getBooksPaging = (page:number,limit:number)=>{
+    return apiClient.get(`/api/books?p=${page}&l=${limit}`);
+}
+
 
 export const getBookDetails=(id:string)=>{
     return apiClient.get(`/api/books/${id}`);

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,0 +1,14 @@
+export const getPageNumbers = (currentPage: number, totalPages: number, maxButtons: number) => {
+    const half = Math.floor(maxButtons / 2);
+    let start = Math.max(1, currentPage - half);
+    let end = Math.min(totalPages, currentPage + half);
+  
+    // 페이지 범위가 부족할 때 조정
+    if (currentPage <= half) {
+      end = Math.min(totalPages, maxButtons);
+    } else if (currentPage + half > totalPages) {
+      start = Math.max(1, totalPages - maxButtons + 1);
+    }
+  
+    return Array.from({ length: end - start + 1 }, (_, i) => start + i);
+  }


### PR DESCRIPTION
기존 : frontend 단에서 전체 데이터를 10개로 나눠서 보여줌
수정 후 : 서버로 page, limit 값을 넣어서 page넘길때마다 요청
이전 데이터는 보존하는 옵션 사용

참고할 점 📔 
- mock api라 data의 totalCount를 모르기때문에 전체 페이지 개수를 전체 데이터를 받아와서 계산했음 
- 현재 검색창 방식이 전체 데이터에서 필터링해서 검색결과를 도출하는 방식이라 결국 전체 데이터가 필요함
- 위의 문제때문에 검색시 찾는 키워드를 쿼리에 담아 서버에 요청하려고 feat/search 브랜치에서 진행중이나 
field_name과 keyword를 담아 서버에 요청할 때 이유 모를 에러로 특정 필드와 값을 비교하는 요청을 보낼 수 없음 
전체 필드와 키워드를 매칭해서 결과를 받아올 수 있는 쿼리 키워드 search, filter가 있으나 이 방식을 이용하면 
저자, 책제목 뿐만이아닌 모든 필드와 값을 매칭해서 비교하게 됨 
